### PR TITLE
Avoid multiple babel-polyfill loaded

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -1,4 +1,7 @@
-import 'babel-polyfill';
+if (!global._babelPolyfill) {
+  require('babel-polyfill');
+}
+
 import { SimpleSchema, ValidationContext } from './SimpleSchema';
 import './clean.js';
 


### PR DESCRIPTION
An error is thrown if a process attempts to load babel-polyfill more than once:

`ERROR in only one instance of babel-polyfill is allowed`.

See shakacode/bootstrap-loader#16
