### PR TITLE
Remove babel-polyfill

### DIFF
--- a/lib/SimpleSchema.js
+++ b/lib/SimpleSchema.js
@@ -678,8 +678,6 @@ function checkSchemaOverlap(schema) {
   _.each(schema, (val, key) => {
     _.each(val.type.definitions, (def) => {
       if (!(def.type instanceof SimpleSchema)) return;
-      console.log(key, def.type);
-
       _.each(def.type._schema, (subVal, subKey) => {
         const newKey = `${key}.${subKey}`;
         if (schema.hasOwnProperty(newKey)) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,4 +1,3 @@
-import 'babel-polyfill';
 import { SimpleSchema, ValidationContext } from './SimpleSchema';
 import './clean.js';
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "test:watch": "npm test -- --watch"
   },
   "dependencies": {
-    "babel-polyfill": "^6.9.1",
     "clone": "^1.0.2",
     "message-box": "0.0.1",
     "mongo-object": "0.0.1",


### PR DESCRIPTION
It's the job of the application to include a polyfill, not of a library.

Fixes #18
