### PR TITLE
Cannot use HTML escaped characters in labels

### DIFF
--- a/lib/SimpleSchema.js
+++ b/lib/SimpleSchema.js
@@ -1,3 +1,4 @@
+import deepExtend from 'deep-extend';
 import MongoObject from 'mongo-object';
 import humanize from './humanize.js';
 import ValidationContext from './ValidationContext';
@@ -64,6 +65,44 @@ const regExpMessages = [
   { exp: regExpObj.Phone, msg: 'must be a valid phone number' },
 ];
 
+const defaultMessages = {
+  initialLanguage: 'en',
+  messages: {
+    en: {
+      required: '{{label}} is required',
+      minString: '{{label}} must be at least {{min}} characters',
+      maxString: '{{label}} cannot exceed {{max}} characters',
+      minNumber: '{{label}} must be at least {{min}}',
+      maxNumber: '{{label}} cannot exceed {{max}}',
+      minNumberExclusive: '{{label}} must be greater than {{min}}',
+      maxNumberExclusive: '{{label}} must be less than {{max}}',
+      minDate: '{{label}} must be on or after {{min}}',
+      maxDate: '{{label}} cannot be after {{max}}',
+      badDate: '{{label}} is not a valid date',
+      minCount: 'You must specify at least {{minCount}} values',
+      maxCount: 'You cannot specify more than {{maxCount}} values',
+      noDecimal: '{{label}} must be an integer',
+      notAllowed: '{{value}} is not an allowed value',
+      expectedType: '{{label}} must be of type {{dataType}}',
+      regEx({
+        label,
+        regExp,
+      }) {
+        // See if there's one where exp matches this expression
+        let msgObj;
+        if (regExp) {
+          msgObj = _.find(regExpMessages, (o) => o.exp && o.exp.toString() === regExp);
+        }
+
+        const regExpMessage = msgObj ? msgObj.msg : 'failed regular expression validation';
+
+        return `${label} ${regExpMessage}`;
+      },
+      keyNotInSchema: '{{name}} is not allowed by the schema',
+    },
+  },
+};
+
 class SimpleSchema {
   constructor(schema = {}, options = {}) {
     // Stash the options object
@@ -82,43 +121,7 @@ class SimpleSchema {
     this.extend(schema);
 
     // Define default validation error messages
-    this.messageBox = new MessageBox({
-      initialLanguage: 'en',
-      messages: {
-        en: {
-          required: '{{label}} is required',
-          minString: '{{label}} must be at least {{min}} characters',
-          maxString: '{{label}} cannot exceed {{max}} characters',
-          minNumber: '{{label}} must be at least {{min}}',
-          maxNumber: '{{label}} cannot exceed {{max}}',
-          minNumberExclusive: '{{label}} must be greater than {{min}}',
-          maxNumberExclusive: '{{label}} must be less than {{max}}',
-          minDate: '{{label}} must be on or after {{min}}',
-          maxDate: '{{label}} cannot be after {{max}}',
-          badDate: '{{label}} is not a valid date',
-          minCount: 'You must specify at least {{minCount}} values',
-          maxCount: 'You cannot specify more than {{maxCount}} values',
-          noDecimal: '{{label}} must be an integer',
-          notAllowed: '{{value}} is not an allowed value',
-          expectedType: '{{label}} must be of type {{dataType}}',
-          regEx({
-            label,
-            regExp,
-          }) {
-            // See if there's one where exp matches this expression
-            let msgObj;
-            if (regExp) {
-              msgObj = _.find(regExpMessages, (o) => o.exp && o.exp.toString() === regExp);
-            }
-
-            const regExpMessage = msgObj ? msgObj.msg : 'failed regular expression validation';
-
-            return `${label} ${regExpMessage}`;
-          },
-          keyNotInSchema: '{{name}} is not allowed by the schema',
-        },
-      },
-    });
+    this.messageBox = new MessageBox(defaultMessages);
 
     // Schema-level defaults for cleaning
     this._cleanOptions = {
@@ -646,6 +649,10 @@ class SimpleSchema {
   // Backwards compatibility
   static _makeGeneric = MongoObject.makeKeyGeneric;
   static ValidationContext = ValidationContext;
+
+  static setDefaultMessages = (messages) => {
+    deepExtend(defaultMessages, messages);
+  };
 }
 
 /*

--- a/lib/SimpleSchema_labels.tests.js
+++ b/lib/SimpleSchema_labels.tests.js
@@ -46,4 +46,14 @@ describe('SimpleSchema - label', function () {
 
     expect(schema.label('obj.someString')).toEqual('A callback label');
   });
+
+  it('should allow apostrophes ("\'") in labels', () => {
+    const schema = new SimpleSchema({
+      foo: {
+        type: String,
+        label: 'Manager/supervisor\'s name',
+      },
+    });
+    expect(schema.label('foo')).toEqual('Manager/supervisor\'s name');
+  });
 });

--- a/lib/SimpleSchema_messages.tests.js
+++ b/lib/SimpleSchema_messages.tests.js
@@ -229,5 +229,18 @@ describe('SimpleSchema', function () {
       context.validate({ bar: 1 });
       expect(context.keyErrorMessage('bar')).toBe('bar is not allowed by the schema');
     });
+
+    it('should allow labels with apostrophes ("\'") in messages', function () {
+      const schema = new SimpleSchema({
+        foo: {
+          type: String,
+          label: 'Manager/supervisor\'s name',
+        },
+      });
+
+      const context = schema.newContext();
+      context.validate({});
+      expect(context.keyErrorMessage('foo')).toBe('Manager/supervisor\'s name is required');
+    });
   });
 });


### PR DESCRIPTION
Added failing test to demonstrate this issue.

Also added a way for users to set default messages.

Issue #22
