### PR TITLE
Updated documentation for node-message-box

### DIFF
--- a/README.md
+++ b/README.md
@@ -835,7 +835,11 @@ If you use a custom string for `type`, be sure to define a message for it. (See 
 Example:
 
 ```js
-SimpleSchema.messages({wrongPassword: "Wrong password"});
+SimpleSchema.messageBox.messages({
+    en: {
+        wrongPassword: "Wrong password"
+    }
+});
 
 myValidationContext.addValidationErrors([{name: "password", type: "wrongPassword"}]);
 ```


### PR DESCRIPTION
- Changed custom error message example from meteor-simple-schema syntax to node-message-box syntax