### PR TITLE
Removing Array.includes references

### DIFF
--- a/lib/clean/setAutoValues.js
+++ b/lib/clean/setAutoValues.js
@@ -30,7 +30,7 @@ function setAutoValues(autoValueFunctions, mongoObject, isModifier, extendedAuto
     const affectedKey = this.key;
 
     // If already called for this key, skip it
-    if (Array.includes(doneKeys, affectedKey)) return;
+    if (_.contains(doneKeys, affectedKey)) return;
 
     const fieldParentName = getParentOfKey(affectedKey, true);
 

--- a/lib/doValidation.js
+++ b/lib/doValidation.js
@@ -279,7 +279,7 @@ function doValidation({
         if (isUpsert && op === '$set') {
           const presentKeys = Object.keys(opObj);
           schema.objectKeys().forEach(schemaKey => {
-            if (!Array.includes(presentKeys, schemaKey)) {
+            if (!_.contains(presentKeys, schemaKey)) {
               checkObj({
                 val: undefined,
                 affectedKey: schemaKey,
@@ -324,9 +324,9 @@ function doValidation({
   const addedFieldNames = [];
   validationErrors = _.filter(validationErrors, errObj => {
     // Remove error types the user doesn't care about
-    if (Array.includes(ignoreTypes, errObj.type)) return false;
+    if (_.contains(ignoreTypes, errObj.type)) return false;
     // Make sure there is only one error per fieldName
-    if (Array.includes(addedFieldNames, errObj.name)) return false;
+    if (_.contains(addedFieldNames, errObj.name)) return false;
 
     addedFieldNames.push(errObj.name);
     return true;

--- a/lib/validation/allowedValuesValidator.js
+++ b/lib/validation/allowedValuesValidator.js
@@ -1,3 +1,5 @@
+import _ from 'underscore';
+
 import { SimpleSchema } from '../SimpleSchema';
 
 function allowedValuesValidator() {
@@ -6,7 +8,7 @@ function allowedValuesValidator() {
   const allowedValues = this.definition.allowedValues;
   if (!allowedValues) return;
 
-  const isAllowed = Array.includes(allowedValues, this.value);
+  const isAllowed = _.contains(allowedValues, this.value);
   return isAllowed ? true : SimpleSchema.ErrorTypes.VALUE_NOT_ALLOWED;
 }
 


### PR DESCRIPTION
Removing `Array.includes`. references in favor of Underscore `_.contains` to fix https://github.com/aldeed/node-simple-schema/issues/33
