### PR TITLE
Fix 'SimpleSchema messages minDate / maxDate tests'

### DIFF
--- a/lib/SimpleSchema_messages.tests.js
+++ b/lib/SimpleSchema_messages.tests.js
@@ -99,12 +99,12 @@ describe('SimpleSchema', function () {
       const schema = new SimpleSchema({
         foo: {
           type: Date,
-          min: new Date(2015, 11, 15, 0, 0, 0, 0),
+          min: new Date(Date.UTC(2015, 11, 15, 0, 0, 0, 0)),
         },
       });
 
       const context = schema.newContext();
-      context.validate({ foo: new Date(2015, 10, 15, 0, 0, 0, 0) });
+      context.validate({ foo: new Date(Date.UTC(2015, 10, 15, 0, 0, 0, 0)) });
       expect(context.keyErrorMessage('foo')).toBe('Foo must be on or after 2015-12-15');
     });
 
@@ -112,12 +112,12 @@ describe('SimpleSchema', function () {
       const schema = new SimpleSchema({
         foo: {
           type: Date,
-          max: new Date(2015, 11, 15, 0, 0, 0, 0),
+          max: new Date(Date.UTC(2015, 11, 15, 0, 0, 0, 0)),
         },
       });
 
       const context = schema.newContext();
-      context.validate({ foo: new Date(2016, 1, 15, 0, 0, 0, 0) });
+      context.validate({ foo: new Date(Date.UTC(2016, 1, 15, 0, 0, 0, 0)) });
       expect(context.keyErrorMessage('foo')).toBe('Foo cannot be after 2015-12-15');
     });
 


### PR DESCRIPTION
This PR solves an issue with running tests in different time zone.
```
  1) SimpleSchema messages minDate:
     Error: Expected 'Foo must be on or after 2015-12-14' to be 'Foo must be on or after 2015-12-15'
  2) SimpleSchema messages maxDate:
     Error: Expected 'Foo cannot be after 2015-12-14' to be 'Foo cannot be after 2015-12-15'
```

For +02:00 in Ukraine node calculates shifted date:

![dates](https://cloud.githubusercontent.com/assets/182339/22622671/8aa8d606-eb49-11e6-8a98-ddc235fbdba2.PNG)

I see two ways to fix this:
  - use UTC dates
  - do not hardcode date in expected result

I've opted UTC dates, but can change PR if other approach is preferred