### PR TITLE
Duck Typing Checks

### DIFF
--- a/lib/SimpleSchema.js
+++ b/lib/SimpleSchema.js
@@ -259,7 +259,7 @@ class SimpleSchema {
     const genericKey = MongoObject.makeKeyGeneric(key);
     const searchString = `${genericKey}.`;
 
-    _.each(this.mergedSchema(), function (val, k) {
+    _.each(this.mergedSchema(), (val, k) => {
       if (k.indexOf(searchString) === 0) {
         newSchemaDef[k.slice(searchString.length)] = val;
       }

--- a/lib/SimpleSchema.js
+++ b/lib/SimpleSchema.js
@@ -104,6 +104,14 @@ class SimpleSchema {
   }
 
   /**
+   * Returns whether the rhs is a SimpleSchema object.
+   * @param {Object} [rhs] An object to test
+   * @returns {Boolean} True if rhs is a SimpleSchema, False otherwise
+   */
+  static isSimpleSchema(rhs) {
+    return (rhs instanceof SimpleSchema || rhs._schema);
+  }
+  /**
    * @param {String} [key] One specific or generic key for which to get the schema.
    * @returns {Object} The entire schema object or just the definition for one key.
    *
@@ -142,7 +150,7 @@ class SimpleSchema {
       mergedSchema[key] = keySchema;
 
       keySchema.type.definitions.forEach(typeDef => {
-        if (!(typeDef.type instanceof SimpleSchema)) return;
+        if (!(SimpleSchema.isSimpleSchema(typeDef.type))) return;
         _.each(typeDef.type.mergedSchema(), (subKeySchema, subKey) => {
           mergedSchema[`${key}.${subKey}`] = subKeySchema;
         });
@@ -279,7 +287,7 @@ class SimpleSchema {
 
     _.each(this._schema, (keySchema, key) => {
       keySchema.type.definitions.forEach(typeDef => {
-        if (!(typeDef.type instanceof SimpleSchema)) return;
+        if (!(SimpleSchema.isSimpleSchema(typeDef.type))) return;
         result = result.concat(typeDef.type.autoValueFunctions().map(({
           func,
           fieldName,
@@ -302,7 +310,7 @@ class SimpleSchema {
     const blackboxKeys = this._blackboxKeys;
     _.each(this._schema, (keySchema, key) => {
       keySchema.type.definitions.forEach(typeDef => {
-        if (!(typeDef.type instanceof SimpleSchema)) return;
+        if (!(SimpleSchema.isSimpleSchema(typeDef.type))) return;
         typeDef.type._blackboxKeys.forEach(blackboxKey => {
           blackboxKeys.push(`${key}.${blackboxKey}`);
         });
@@ -321,7 +329,7 @@ class SimpleSchema {
         const testKeySchema = this.schema(ancestor);
         if (testKeySchema) {
           testKeySchema.type.definitions.forEach(typeDef => {
-            if (!(typeDef.type instanceof SimpleSchema)) return;
+            if (!(SimpleSchema.isSimpleSchema(typeDef.type))) return;
             if (typeDef.type.keyIsInBlackBox(remainder)) isInBlackBox = true;
           });
         }
@@ -359,7 +367,7 @@ class SimpleSchema {
       let allowed = false;
       const subKey = key.slice(loopKey.length + 1);
       fieldSchema.type.definitions.forEach(typeDef => {
-        if (!(typeDef.type instanceof SimpleSchema)) return;
+        if (!(SimpleSchema.isSimpleSchema(typeDef.type))) return;
         if (typeDef.type.allowsKey(subKey)) allowed = true;
       });
       return allowed;
@@ -387,7 +395,7 @@ class SimpleSchema {
    */
   extend(schema = {}) {
     let schemaObj;
-    if (schema instanceof SimpleSchema) {
+    if (SimpleSchema.isSimpleSchema(schema)) {
       schemaObj = schema._schema;
       // Merge the validators
       this._validators = this._validators.concat(schema._validators);
@@ -446,7 +454,7 @@ class SimpleSchema {
         // If the current field is a nested SimpleSchema,
         // iterate over the child fields and cache their properties as well
         definition.type.definitions.forEach(({ type }) => {
-          if (type instanceof SimpleSchema) {
+          if (SimpleSchema.isSimpleSchema(type)) {
             setObjectKeys(type._schema, fieldName);
           }
         });
@@ -640,7 +648,7 @@ class SimpleSchema {
 
   static validate(obj, schema, options) {
     // Allow passing just the schema object
-    if (!(schema instanceof SimpleSchema)) {
+    if (!(SimpleSchema.isSimpleSchema(schema))) {
       schema = new SimpleSchema(schema);
     }
 
@@ -725,7 +733,7 @@ function checkSchemaOverlap(schema) {
   _.each(schema, (val, key) => {
     if (!val.type) throw new Error(`${key} key is missing "type"`);
     _.each(val.type.definitions, (def) => {
-      if (!(def.type instanceof SimpleSchema)) return;
+      if (!(SimpleSchema.isSimpleSchema(def.type))) return;
 
       _.each(def.type._schema, (subVal, subKey) => {
         const newKey = `${key}.${subKey}`;
@@ -787,7 +795,7 @@ function checkAndScrubDefinition(fieldName, definition, options, fullSchemaObj) 
       throw new Error(`Invalid definition for ${fieldName} field: "type" may not be an array. Change it to Array.`);
     }
 
-    if (type instanceof SimpleSchema) {
+    if (SimpleSchema.isSimpleSchema(type)) {
       _.each(type._schema, (subVal, subKey) => {
         const newKey = `${fieldName}.${subKey}`;
         if (fullSchemaObj.hasOwnProperty(newKey)) {

--- a/lib/SimpleSchema.js
+++ b/lib/SimpleSchema.js
@@ -104,12 +104,12 @@ class SimpleSchema {
   }
 
   /**
-   * Returns whether the rhs is a SimpleSchema object.
-   * @param {Object} [rhs] An object to test
+   * Returns whether the obj is a SimpleSchema object.
+   * @param {Object} [obj] An object to test
    * @returns {Boolean} True if rhs is a SimpleSchema, False otherwise
    */
-  static isSimpleSchema(rhs) {
-    return (rhs instanceof SimpleSchema || rhs._schema);
+  static isSimpleSchema(obj) {
+    return (obj && (obj instanceof SimpleSchema || obj._schema));
   }
   /**
    * @param {String} [key] One specific or generic key for which to get the schema.

--- a/lib/SimpleSchema_getObjectSchema.tests.js
+++ b/lib/SimpleSchema_getObjectSchema.tests.js
@@ -18,7 +18,7 @@ describe('SimpleSchema', function () {
         },
         'foo.bbb.zzz': {
           type: Number,
-        }
+        },
       });
 
       const newSchema = schema.getObjectSchema('foo');
@@ -54,7 +54,7 @@ describe('SimpleSchema', function () {
         },
         'foo.bbb.zzz': {
           type: Number,
-        }
+        },
       });
 
       const newSchema = schema.getObjectSchema('foo.bbb');
@@ -114,7 +114,7 @@ describe('SimpleSchema', function () {
           },
           'bbb.zzz': {
             type: Number,
-          }
+          },
         }),
       });
 


### PR DESCRIPTION
This PR refactors out ```schema instanceof SimpleSchema``` into a centralized ```static SimpleSchema.isSimpleSchema(obj)``` call as discussed in #64 
Also addresses a couple of minor eslint warnings/errors that were floating around.

This does not include test cases for the other errors discussed in that thread (#64).