### PR TITLE
Add isInteger polyfill for IE11

### DIFF
--- a/lib/validation/doNumberChecks.js
+++ b/lib/validation/doNumberChecks.js
@@ -1,5 +1,12 @@
 import { SimpleSchema } from '../SimpleSchema';
 
+// Polyfill to support IE11
+Number.isInteger = Number.isInteger || function(value) {
+  return typeof value === "number" &&
+    isFinite(value) &&
+    Math.floor(value) === value;
+};
+
 function doNumberChecks(def, keyValue, op, expectsInteger) {
   // Is it a valid number?
   if (typeof keyValue !== 'number' || isNaN(keyValue)) {


### PR DESCRIPTION
> Object doesn't support property or method 'isInteger'

This error happens in IE11. Number.isInteger is ES6 which is not supported in IE11.

[CanIUse](http://caniuse.com/#search=isinteger)
[Number.isInteger Polyfill](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isInteger)