### PR TITLE
Multiple schema issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ dist
 .DS_Store
 node_modules
 npm-debug.log
+.idea

--- a/lib/SimpleSchema.js
+++ b/lib/SimpleSchema.js
@@ -2,6 +2,7 @@ import deepExtend from 'deep-extend';
 import MongoObject from 'mongo-object';
 import _ from 'underscore';
 import MessageBox from 'message-box';
+import clone from 'clone';
 import humanize from './humanize.js';
 import ValidationContext from './ValidationContext';
 import SimpleSchemaGroup from './SimpleSchemaGroup';
@@ -67,7 +68,7 @@ class SimpleSchema {
     this.extend(schema);
 
     // Define default validation error messages
-    this.messageBox = new MessageBox(defaultMessages);
+    this.messageBox = new MessageBox(clone(defaultMessages));
 
     // Schema-level defaults for cleaning
     this._cleanOptions = {

--- a/lib/SimpleSchema_messages.tests.js
+++ b/lib/SimpleSchema_messages.tests.js
@@ -265,4 +265,37 @@ describe('SimpleSchema', function () {
       expect(context.keyErrorMessage('foo')).toBe('Manager/supervisor\'s name is required');
     });
   });
+
+  describe('multipleSchema', function () {
+    const schema = new SimpleSchema({
+      foo: String,
+    });
+
+    schema.messageBox.messages({
+      en: {
+        required: {
+          foo: 'Your foo is required mate',
+        },
+      },
+    });
+
+    const schema2 = new SimpleSchema({
+      foo: String,
+      bar: Number,
+    });
+
+    schema2.messageBox.messages({
+      en: {
+        required: {
+          foo: 'Your bar is required for sure',
+        },
+      },
+    });
+
+    it('should keep message boxes separate between objects', function () {
+      const context = schema.newContext();
+      context.validate({});
+      expect(context.keyErrorMessage('foo')).toBe('Your foo is required mate');
+    });
+  });
 });


### PR DESCRIPTION
When using the messageBox property of a SimpleSchema instance, any messages passed in mutate the messageBox for every SimpleSchema instance in the project. See the following example:

```ts
const schema = new SimpleSchema({
  foo: String,
});

schema.messageBox.messages({
  en: {
    required: {
      foo: 'Your foo is required mate',
    },
  },
});

const schema2 = new SimpleSchema({
  foo: String,
  bar: Number,
});

schema2.messageBox.messages({
  en: {
    required: {
      foo: 'Your bar is required for sure',
    },
  },
});

const context = schema.newContext();
context.validate({});
console.log(context.keyErrorMessage('foo'));
```

One would expect the output to the console to read "Your foo is required mate". In reality, the second error message "Your bar is required for sure" is the output, as the second call to messageBox.messages mutates both schemas' messageBox properties.