### PR TITLE
Ensure defaultValue never sets string key on array (#80)

### DIFF
--- a/lib/SimpleSchema.tests.js
+++ b/lib/SimpleSchema.tests.js
@@ -177,6 +177,50 @@ describe('SimpleSchema', function () {
     });
   });
 
+  it('Safely sets defaultValues on subschemas nested in arrays', function () {
+    const nestedSchema = new SimpleSchema({
+      nested: {
+        type: Array,
+      },
+      'nested.$': {
+        type: new SimpleSchema({
+          somethingOptional: {
+            type: String,
+            optional: true,
+          },
+          somethingAutovalued: {
+            type: String,
+            optional: false,
+            defaultValue: 'x',
+          }
+        }),
+      },
+    });
+
+    let context = nestedSchema.newContext();
+    const cleaned = context.clean({ 
+      $set: {
+        nested: [
+          {somethingOptional: 'q'},
+          {somethingOptional: 'z'},
+        ],
+      },
+    }, {modifier: true});
+    
+    expect(cleaned).toEqual({
+      $set: {
+        nested: [
+          {somethingOptional: "q"},
+          {somethingOptional: "z"},
+        ]
+      },
+      $setOnInsert: {
+        "nested.0.somethingAutovalued": "x",
+        "nested.1.somethingAutovalued": "x",
+      }
+    });
+  });
+
   it('Issue #123', function () {
     // With $set
     const userSchema = new SimpleSchema({

--- a/lib/clean/setAutoValues.js
+++ b/lib/clean/setAutoValues.js
@@ -35,6 +35,14 @@ function setAutoValues(autoValueFunctions, mongoObject, isModifier, extendedAuto
     const fieldParentName = getParentOfKey(affectedKey, true);
 
     let doUnset = false;
+
+    if (_.isArray(getFieldInfo(fieldParentName.slice(0,-1)).value)) {
+      if (isNaN(this.key.split('.').slice(-1).pop())) {
+        // parent is an array, but the key to be set is not an integer (see issue #80)
+        return;
+      }
+    }
+
     const autoValue = func.call({
       isSet: (this.value !== undefined),
       unset() {


### PR DESCRIPTION
This PR fixes the problem discussed in #80; includes a corresponding test.

The added check simply ensures that a situation does not emerge in which an autoValue / defaultValue function attempts to set a string key on any array itself rather than its members. 