### PR TITLE
Replaced underscore by lodash methods or es6 alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -1174,3 +1174,5 @@ Anyone is welcome to contribute. Before submitting a pull request, make sure tha
 
 - @mquandalle
 - @Nemo64
+- @DavidSichau
+

--- a/lib/SimpleSchema.js
+++ b/lib/SimpleSchema.js
@@ -1,6 +1,8 @@
 import deepExtend from 'deep-extend';
 import MongoObject from 'mongo-object';
-import _ from 'underscore';
+import forEach from 'lodash.foreach';
+import omit from 'lodash.omit';
+import pick from 'lodash.pick';
 import MessageBox from 'message-box';
 import clone from 'clone';
 import humanize from './humanize.js';
@@ -148,12 +150,12 @@ class SimpleSchema {
   mergedSchema() {
     const mergedSchema = {};
 
-    _.each(this._schema, (keySchema, key) => {
+    forEach(this._schema, (keySchema, key) => {
       mergedSchema[key] = keySchema;
 
       keySchema.type.definitions.forEach(typeDef => {
         if (!(SimpleSchema.isSimpleSchema(typeDef.type))) return;
-        _.each(typeDef.type.mergedSchema(), (subKeySchema, subKey) => {
+        forEach(typeDef.type.mergedSchema(), (subKeySchema, subKey) => {
           mergedSchema[`${key}.${subKey}`] = subKeySchema;
         });
       });
@@ -176,7 +178,7 @@ class SimpleSchema {
 
     const getPropIterator = obj => {
       return (val, prop) => {
-        if (Array.isArray(propList) && !_.contains(propList, prop)) return;
+        if (Array.isArray(propList) && !propList.includes(prop)) return;
         // For any options that support specifying a function, evaluate the functions
         if (propsThatCanBeFunction.indexOf(prop) > -1 && typeof val === 'function') {
           obj[prop] = val.call(functionContext || {});
@@ -189,14 +191,14 @@ class SimpleSchema {
     };
 
     const result = {};
-    _.each(defs, getPropIterator(result));
+    forEach(defs, getPropIterator(result));
 
     // Resolve all the types and convert to a normal array to make it easier
     // to use.
     if (defs.type) {
       result.type = defs.type.definitions.map(typeDef => {
         const newTypeDef = {};
-        _.each(typeDef, getPropIterator(newTypeDef));
+        forEach(typeDef, getPropIterator(newTypeDef));
         return newTypeDef;
       });
     }
@@ -263,7 +265,7 @@ class SimpleSchema {
     const genericKey = MongoObject.makeKeyGeneric(key);
     const searchString = `${genericKey}.`;
 
-    _.each(this.mergedSchema(), (val, k) => {
+    forEach(this.mergedSchema(), (val, k) => {
       if (k.indexOf(searchString) === 0) {
         newSchemaDef[k.slice(searchString.length)] = val;
       }
@@ -278,7 +280,7 @@ class SimpleSchema {
     let result = [];
 
     function addFuncs(autoValues, closestSubschemaFieldName) {
-      _.each(autoValues, (func, fieldName) => {
+      forEach(autoValues, (func, fieldName) => {
         result.push({
           func,
           fieldName,
@@ -289,7 +291,7 @@ class SimpleSchema {
 
     addFuncs(this._autoValues, '');
 
-    _.each(this._schema, (keySchema, key) => {
+    forEach(this._schema, (keySchema, key) => {
       keySchema.type.definitions.forEach(typeDef => {
         if (!(SimpleSchema.isSimpleSchema(typeDef.type))) return;
         result = result.concat(typeDef.type.autoValueFunctions().map(({
@@ -312,7 +314,7 @@ class SimpleSchema {
   // Returns an array of all the blackbox keys, including those in subschemas
   blackboxKeys() {
     const blackboxKeys = this._blackboxKeys;
-    _.each(this._schema, (keySchema, key) => {
+    forEach(this._schema, (keySchema, key) => {
       keySchema.type.definitions.forEach(typeDef => {
         if (!(SimpleSchema.isSimpleSchema(typeDef.type))) return;
         typeDef.type._blackboxKeys.forEach(blackboxKey => {
@@ -320,7 +322,7 @@ class SimpleSchema {
         });
       });
     });
-    return _.uniq(blackboxKeys);
+    return [... new Set(blackboxKeys)];
   }
 
   // Check if the key is a nested dot-syntax key inside of a blackbox object
@@ -347,7 +349,7 @@ class SimpleSchema {
   // The key string should have $ in place of any numeric array positions.
   allowsKey(key) {
     // Loop through all keys in the schema
-    return _.any(this._schemaKeys, loopKey => {
+    return this._schemaKeys.some(loopKey => {
       // If the schema key is the test key, it's allowed.
       if (loopKey === key) return true;
 
@@ -422,7 +424,7 @@ class SimpleSchema {
     this._objectKeys = {};
 
     // Update all of the information cached on the instance
-    _.each(this._schema, (definition, fieldName) => {
+    forEach(this._schema, (definition, fieldName) => {
       this._schema[fieldName] = definition = checkAndScrubDefinition(fieldName, definition, this._constructorOptions, this._schema);
 
       // Keep list of all keys for speedier checking
@@ -446,7 +448,7 @@ class SimpleSchema {
     // Store child keys keyed by parent. This needs to be done recursively to handle
     // subschemas.
     const setObjectKeys = (curSchema, schemaParentKey) => {
-      _.each(curSchema, (definition, fieldName) => {
+      forEach(curSchema, (definition, fieldName) => {
         fieldName = schemaParentKey ? `${schemaParentKey}.${fieldName}` : fieldName;
         if (fieldName.indexOf('.') > -1 && fieldName.slice(-2) !== '.$') {
           const parentKey = fieldName.slice(0, fieldName.lastIndexOf('.'));
@@ -572,7 +574,7 @@ class SimpleSchema {
    * @param {Object} labels A dictionary of all the new label values, by schema key.
    */
   labels(labels) {
-    _.each(labels, (label, key) => {
+    forEach(labels, (label, key) => {
       if (typeof label !== 'string' && typeof label !== 'function') return;
       if (!this._schema.hasOwnProperty(key)) return;
 
@@ -592,7 +594,7 @@ class SimpleSchema {
     // Get all labels
     if (key === null || key === undefined) {
       const result = {};
-      _.each(this._schemaKeys, (schemaKey) => {
+      forEach(this._schemaKeys, (schemaKey) => {
         result[schemaKey] = this.label(schemaKey);
       });
       return result;
@@ -621,7 +623,7 @@ class SimpleSchema {
 
     if (!def) return undefined;
 
-    if (_.contains(schemaDefinitionOptions, prop)) {
+    if (schemaDefinitionOptions.includes(prop)) {
       return def[prop];
     }
 
@@ -743,11 +745,11 @@ class SimpleSchema {
 
 function mergeSchemas(schemas) {
   const mergedSchema = {};
-  _.each(schemas, schema => {
+  forEach(schemas, schema => {
     // Loop through and extend each individual field
     // definition. That way you can extend and overwrite
     // base field definitions.
-    _.each(schema, (def, field) => {
+    forEach(schema, (def, field) => {
       mergedSchema[field] = mergedSchema[field] || {};
       if (!(mergedSchema[field] instanceof SimpleSchemaGroup)) {
         if (def instanceof SimpleSchemaGroup) {
@@ -764,12 +766,12 @@ function mergeSchemas(schemas) {
 // Throws an error if any fields are `type` SimpleSchema but then also
 // have subfields defined outside of that.
 function checkSchemaOverlap(schema) {
-  _.each(schema, (val, key) => {
+  forEach(schema, (val, key) => {
     if (!val.type) throw new Error(`${key} key is missing "type"`);
-    _.each(val.type.definitions, (def) => {
+    forEach(val.type.definitions, (def) => {
       if (!(SimpleSchema.isSimpleSchema(def.type))) return;
 
-      _.each(def.type._schema, (subVal, subKey) => {
+      forEach(def.type._schema, (subVal, subKey) => {
         const newKey = `${key}.${subKey}`;
         if (schema.hasOwnProperty(newKey)) {
           throw new Error(`The type for "${key}" is set to a SimpleSchema instance that defines "${key}.${subKey}", but the parent SimpleSchema instance also tries to define "${key}.${subKey}"`);
@@ -808,14 +810,14 @@ function checkAndScrubDefinition(fieldName, definition, options, fullSchemaObj) 
 
   // Internally, all definition types are stored as groups for simplicity of access
   if (!(internalDefinition.type instanceof SimpleSchemaGroup)) {
-    internalDefinition.type = new SimpleSchemaGroup(_.pick(internalDefinition, oneOfProps));
+    internalDefinition.type = new SimpleSchemaGroup(pick(internalDefinition, oneOfProps));
   }
 
   // Limit to only the non-oneOf props
-  internalDefinition = _.omit(internalDefinition, _.without(oneOfProps, 'type'));
+  internalDefinition = omit(internalDefinition, oneOfProps.filter(e => e !== 'type'));
 
   // Validate the field definition
-  _.each(internalDefinition, (val, key) => {
+  forEach(internalDefinition, (val, key) => {
     if (schemaDefinitionOptions.indexOf(key) === -1) {
       throw new Error(`Invalid definition for ${fieldName} field: "${key}" is not a supported property`);
     }
@@ -830,7 +832,7 @@ function checkAndScrubDefinition(fieldName, definition, options, fullSchemaObj) 
     }
 
     if (SimpleSchema.isSimpleSchema(type)) {
-      _.each(type._schema, (subVal, subKey) => {
+      forEach(type._schema, (subVal, subKey) => {
         const newKey = `${fieldName}.${subKey}`;
         if (fullSchemaObj.hasOwnProperty(newKey)) {
           throw new Error(`The type for "${fieldName}" is set to a SimpleSchema instance that defines "${newKey}", but the parent SimpleSchema instance also tries to define "${newKey}"`);
@@ -895,10 +897,10 @@ function getPickOrOmit(type) {
   return function pickOrOmit(...args) {
     // If they are picking/omitting an object or array field, we need to also include everything under it
     const newSchema = {};
-    _.each(this._schema, (value, key) => {
+    forEach(this._schema, (value, key) => {
       // Pick/omit it if it IS in the array of keys they want OR if it
       // STARTS WITH something that is in the array plus a period
-      const includeIt = _.any(args, wantedField => key === wantedField || key.indexOf(`${wantedField}.`) === 0);
+      const includeIt = args.some(wantedField => key === wantedField || key.indexOf(`${wantedField}.`) === 0);
 
       if ((includeIt && type === 'pick') || (!includeIt && type === 'omit')) {
         newSchema[key] = value;

--- a/lib/SimpleSchema.js
+++ b/lib/SimpleSchema.js
@@ -3,7 +3,9 @@ import MongoObject from 'mongo-object';
 import forEach from 'lodash.foreach';
 import omit from 'lodash.omit';
 import pick from 'lodash.pick';
+import uniq from 'lodash.uniq';
 import MessageBox from 'message-box';
+import includes from 'lodash.includes';
 import clone from 'clone';
 import humanize from './humanize.js';
 import ValidationContext from './ValidationContext';
@@ -178,7 +180,7 @@ class SimpleSchema {
 
     const getPropIterator = obj => {
       return (val, prop) => {
-        if (Array.isArray(propList) && !propList.includes(prop)) return;
+        if (Array.isArray(propList) && !includes(propList, prop)) return;
         // For any options that support specifying a function, evaluate the functions
         if (propsThatCanBeFunction.indexOf(prop) > -1 && typeof val === 'function') {
           obj[prop] = val.call(functionContext || {});
@@ -322,7 +324,7 @@ class SimpleSchema {
         });
       });
     });
-    return [... new Set(blackboxKeys)];
+    return uniq(blackboxKeys);
   }
 
   // Check if the key is a nested dot-syntax key inside of a blackbox object
@@ -623,7 +625,7 @@ class SimpleSchema {
 
     if (!def) return undefined;
 
-    if (schemaDefinitionOptions.includes(prop)) {
+    if (includes(schemaDefinitionOptions, prop)) {
       return def[prop];
     }
 

--- a/lib/ValidationContext.js
+++ b/lib/ValidationContext.js
@@ -1,6 +1,6 @@
 import MongoObject from 'mongo-object';
 import doValidation from './doValidation.js';
-import _ from 'underscore';
+import findWhere from 'lodash.findwhere';
 
 export default class ValidationContext {
   constructor(ss) {
@@ -36,8 +36,8 @@ export default class ValidationContext {
   }
 
   setValidationErrors(errors) {
-    const previousValidationErrors = _.pluck(this._validationErrors, 'name');
-    const newValidationErrors = _.pluck(errors, 'name');
+    const previousValidationErrors = this._validationErrors.map(o => o.name);
+    const newValidationErrors = errors.map(o => o.name);
 
     this._validationErrors = errors;
 
@@ -47,7 +47,7 @@ export default class ValidationContext {
   }
 
   addValidationErrors(errors) {
-    const newValidationErrors = _.pluck(errors, 'name');
+    const newValidationErrors = errors.map(o => o.name);
 
     for (const error of errors) {
       this._validationErrors.push(error);
@@ -64,7 +64,7 @@ export default class ValidationContext {
 
   getErrorForKey(key, genericKey = MongoObject.makeKeyGeneric(key)) {
     const errors = this._validationErrors;
-    return _.findWhere(errors, { name: key }) || _.findWhere(errors, { name: genericKey });
+    return findWhere(errors, { name: key }) || findWhere(errors, { name: genericKey });
   }
 
   _keyIsInvalid(key, genericKey) {
@@ -115,7 +115,7 @@ export default class ValidationContext {
       // are any other existing errors that are NOT in the keys list,
       // we should keep these errors.
       for (const error of this._validationErrors) {
-        const wasValidated = _.any(keysToValidate, key => key === error.name || error.name.startsWith(`${key}.`));
+        const wasValidated = keysToValidate.some(key => key === error.name || error.name.startsWith(`${key}.`));
         if (!wasValidated) validationErrors.push(error);
       }
     }

--- a/lib/clean.js
+++ b/lib/clean.js
@@ -1,5 +1,5 @@
 import MongoObject from 'mongo-object';
-import _ from 'underscore';
+import isEmpty from 'lodash.isempty';
 import { looksLikeModifier } from './utility.js';
 import { SimpleSchema } from './SimpleSchema';
 import convertToProperType from './clean/convertToProperType';
@@ -117,7 +117,7 @@ function clean(ss, doc, options = {}) {
       if (lastBrace === -1) continue;
       const removedPositionParent = removedPosition.slice(0, lastBrace);
       const value = mongoObject.getValueForPosition(removedPositionParent);
-      if (_.isEmpty(value)) mongoObject.removeValueForPosition(removedPositionParent);
+      if (isEmpty(value)) mongoObject.removeValueForPosition(removedPositionParent);
     }
 
     mongoObject.removeArrayItems();
@@ -130,7 +130,7 @@ function clean(ss, doc, options = {}) {
   // since MongoDB 2.6+ will throw errors.
   if (options.isModifier) {
     Object.keys(cleanDoc || {}).forEach(op => {
-      if (_.isEmpty(cleanDoc[op])) delete cleanDoc[op];
+      if (isEmpty(cleanDoc[op])) delete cleanDoc[op];
     });
   }
 

--- a/lib/clean/setAutoValues.js
+++ b/lib/clean/setAutoValues.js
@@ -1,7 +1,7 @@
 import forEach from 'lodash.foreach';
 import MongoObject from 'mongo-object';
 import { getParentOfKey } from '../utility.js';
-
+import includes from 'lodash.includes';
 /**
  * @method setAutoValues
  * @private
@@ -30,7 +30,7 @@ function setAutoValues(autoValueFunctions, mongoObject, isModifier, extendedAuto
     const affectedKey = this.key;
 
     // If already called for this key, skip it
-    if (doneKeys.includes(affectedKey)) return;
+    if (includes(doneKeys, affectedKey)) return;
 
     const fieldParentName = getParentOfKey(affectedKey, true);
 

--- a/lib/clean/setAutoValues.js
+++ b/lib/clean/setAutoValues.js
@@ -1,4 +1,4 @@
-import _ from 'underscore';
+import forEach from 'lodash.foreach';
 import MongoObject from 'mongo-object';
 import { getParentOfKey } from '../utility.js';
 
@@ -30,13 +30,13 @@ function setAutoValues(autoValueFunctions, mongoObject, isModifier, extendedAuto
     const affectedKey = this.key;
 
     // If already called for this key, skip it
-    if (_.contains(doneKeys, affectedKey)) return;
+    if (doneKeys.includes(affectedKey)) return;
 
     const fieldParentName = getParentOfKey(affectedKey, true);
 
     let doUnset = false;
 
-    if (_.isArray(getFieldInfo(fieldParentName.slice(0,-1)).value)) {
+    if (Array.isArray(getFieldInfo(fieldParentName.slice(0,-1)).value)) {
       if (isNaN(this.key.split('.').slice(-1).pop())) {
         // parent is an array, but the key to be set is not an integer (see issue #80)
         return;
@@ -99,7 +99,7 @@ function setAutoValues(autoValueFunctions, mongoObject, isModifier, extendedAuto
     mongoObject.setValueForPosition(this.position, autoValue);
   }
 
-  _.each(autoValueFunctions, ({ func, fieldName, closestSubschemaFieldName }) => {
+  forEach(autoValueFunctions, ({ func, fieldName, closestSubschemaFieldName }) => {
     // autoValue should run for the exact key only, for each array item if under array
     // should run whenever
     // 1 it is set
@@ -124,7 +124,7 @@ function setAutoValues(autoValueFunctions, mongoObject, isModifier, extendedAuto
           lastPart = fieldName.replace(`${test}.`, '');
           if (lastPart.startsWith('$.')) lastPart = lastPart.slice(2);
         }
-        currentPositions = _.map(currentPositions, position => {
+        currentPositions = currentPositions.map(position => {
           position.key = `${position.key}.${lastPart}`;
           position.position = `${position.position}[${lastPart.replace(/\./g, '][')}]`;
           position.value = mongoObject.getValueForPosition(position.position);
@@ -155,7 +155,7 @@ function setAutoValues(autoValueFunctions, mongoObject, isModifier, extendedAuto
 
     // Run the autoValue function once for each place in the object that
     // has a value or that potentially should.
-    _.each(positions, position => {
+    forEach(positions, position => {
       runAV.call(position, func, closestSubschemaFieldName);
     });
   });

--- a/lib/defaultMessages.js
+++ b/lib/defaultMessages.js
@@ -1,4 +1,3 @@
-import _ from 'underscore';
 import regExpObj from './regExp';
 
 const regExpMessages = [
@@ -41,7 +40,7 @@ const defaultMessages = {
         // See if there's one where exp matches this expression
         let msgObj;
         if (regExp) {
-          msgObj = _.find(regExpMessages, (o) => o.exp && o.exp.toString() === regExp);
+          msgObj = regExpMessages.find((o) => o.exp && o.exp.toString() === regExp);
         }
 
         const regExpMessage = msgObj ? msgObj.msg : 'failed regular expression validation';

--- a/lib/defaultMessages.js
+++ b/lib/defaultMessages.js
@@ -1,4 +1,5 @@
 import regExpObj from './regExp';
+import find from 'lodash.find';
 
 const regExpMessages = [
   { exp: regExpObj.Email, msg: 'must be a valid email address' },
@@ -40,7 +41,7 @@ const defaultMessages = {
         // See if there's one where exp matches this expression
         let msgObj;
         if (regExp) {
-          msgObj = regExpMessages.find((o) => o.exp && o.exp.toString() === regExp);
+          msgObj = find(regExpMessages, (o) => o.exp && o.exp.toString() === regExp);
         }
 
         const regExpMessage = msgObj ? msgObj.msg : 'failed regular expression validation';

--- a/lib/doValidation.js
+++ b/lib/doValidation.js
@@ -1,5 +1,8 @@
 import MongoObject from 'mongo-object';
-import _ from 'underscore';
+import forEach from 'lodash.foreach';
+import omit from 'lodash.omit';
+import isObject from 'lodash.isobject';
+import union from 'lodash.union';
 import { SimpleSchema } from './SimpleSchema';
 import { appendAffectedKey, getParentOfKey, looksLikeModifier, isObjectWeShouldTraverse } from './utility.js';
 import typeValidator from './validation/typeValidator';
@@ -23,7 +26,7 @@ function doValidation({
   validationContext,
 }) {
   // First do some basic checks of the object, and throw errors if necessary
-  if (!_.isObject(obj)) {
+  if (!isObject(obj)) {
     throw new Error('The first argument of validate() must be an object');
   }
 
@@ -117,14 +120,14 @@ function doValidation({
 
     // Loop through each of the definitions in the SimpleSchemaGroup.
     // If any return true, we're valid.
-    const fieldIsValid = _.some(def.type, typeDef => {
+    const fieldIsValid = def.type.some(typeDef => {
       const finalValidatorContext = {
         ...validatorContext,
 
         // Take outer definition props like "optional" and "label"
         // and add them to inner props like "type" and "min"
         definition: {
-          ..._.omit(def, 'type'),
+          ...omit(def, 'type'),
           ...typeDef,
         },
       };
@@ -138,7 +141,7 @@ function doValidation({
 
       // We use _.every just so that we don't continue running more validator
       // functions after the first one returns false or an error string.
-      return _.every(fieldValidators, validator => {
+      return fieldValidators.every(validator => {
         const result = validator.call(finalValidatorContext);
 
         // If the validator returns a string, assume it is the
@@ -197,7 +200,7 @@ function doValidation({
       affectedKeyGeneric = MongoObject.makeKeyGeneric(affectedKey);
       def = schema.getDefinition(affectedKey);
 
-      const shouldValidateKey = !keysToValidate || _.any(keysToValidate, keyToValidate => (
+      const shouldValidateKey = !keysToValidate || keysToValidate.some(keyToValidate => (
         keyToValidate === affectedKey ||
         keyToValidate === affectedKeyGeneric ||
         affectedKey.startsWith(`${keyToValidate}.`) ||
@@ -223,7 +226,7 @@ function doValidation({
 
     // Loop through arrays
     if (Array.isArray(val)) {
-      _.each(val, (v, i) => {
+      forEach(val, (v, i) => {
         checkObj({
           val: v,
           affectedKey: `${affectedKey}.${i}`,
@@ -239,14 +242,14 @@ function doValidation({
       // Check all present keys plus all keys defined by the schema.
       // This allows us to detect extra keys not allowed by the schema plus
       // any missing required keys, and to run any custom functions for other keys.
-      const keysToCheck = _.union(presentKeys, childKeys);
+      const keysToCheck = union(presentKeys, childKeys);
 
       // If this object is within an array, make sure we check for
       // required as if it's not a modifier
       isInArrayItemObject = (affectedKeyGeneric && affectedKeyGeneric.slice(-2) === '.$');
 
       // Check all keys in the merged list
-      _.each(keysToCheck, key => {
+      forEach(keysToCheck, key => {
         checkObj({
           val: val[key],
           affectedKey: appendAffectedKey(affectedKey, key),
@@ -271,7 +274,7 @@ function doValidation({
     }
 
     // Loop through operators
-    _.each(mod, (opObj, op) => {
+    forEach(mod, (opObj, op) => {
       // If non-operators are mixed in, throw error
       if (op.slice(0, 1) !== '$') {
         throw new Error(`Expected '${op}' to be a modifier operator like '$set'`);
@@ -282,7 +285,7 @@ function doValidation({
         if (isUpsert && op === '$set') {
           const presentKeys = Object.keys(opObj);
           schema.objectKeys().forEach(schemaKey => {
-            if (!_.contains(presentKeys, schemaKey)) {
+            if (!presentKeys.includes(schemaKey)) {
               checkObj({
                 val: undefined,
                 affectedKey: schemaKey,
@@ -291,7 +294,7 @@ function doValidation({
             }
           });
         }
-        _.each(opObj, (v, k) => {
+        forEach(opObj, (v, k) => {
           if (op === '$push' || op === '$addToSet') {
             if (typeof v === 'object' && '$each' in v) {
               v = v.$each;
@@ -325,11 +328,11 @@ function doValidation({
   });
 
   const addedFieldNames = [];
-  validationErrors = _.filter(validationErrors, errObj => {
+  validationErrors = validationErrors.filter(errObj => {
     // Remove error types the user doesn't care about
-    if (_.contains(ignoreTypes, errObj.type)) return false;
+    if (ignoreTypes.includes(errObj.type)) return false;
     // Make sure there is only one error per fieldName
-    if (_.contains(addedFieldNames, errObj.name)) return false;
+    if (addedFieldNames.includes(errObj.name)) return false;
 
     addedFieldNames.push(errObj.name);
     return true;

--- a/lib/doValidation.js
+++ b/lib/doValidation.js
@@ -3,6 +3,7 @@ import forEach from 'lodash.foreach';
 import omit from 'lodash.omit';
 import isObject from 'lodash.isobject';
 import union from 'lodash.union';
+import includes from 'lodash.includes';
 import { SimpleSchema } from './SimpleSchema';
 import { appendAffectedKey, getParentOfKey, looksLikeModifier, isObjectWeShouldTraverse } from './utility.js';
 import typeValidator from './validation/typeValidator';
@@ -285,7 +286,7 @@ function doValidation({
         if (isUpsert && op === '$set') {
           const presentKeys = Object.keys(opObj);
           schema.objectKeys().forEach(schemaKey => {
-            if (!presentKeys.includes(schemaKey)) {
+            if (!includes(presentKeys, schemaKey)) {
               checkObj({
                 val: undefined,
                 affectedKey: schemaKey,
@@ -330,9 +331,9 @@ function doValidation({
   const addedFieldNames = [];
   validationErrors = validationErrors.filter(errObj => {
     // Remove error types the user doesn't care about
-    if (ignoreTypes.includes(errObj.type)) return false;
+    if (includes(ignoreTypes, errObj.type)) return false;
     // Make sure there is only one error per fieldName
-    if (addedFieldNames.includes(errObj.name)) return false;
+    if (includes(addedFieldNames, errObj.name)) return false;
 
     addedFieldNames.push(errObj.name);
     return true;

--- a/lib/expandShorthand.js
+++ b/lib/expandShorthand.js
@@ -1,5 +1,6 @@
-import _ from 'underscore';
+import forEach from 'lodash.foreach';
 import MongoObject from 'mongo-object';
+
 
 /**
  * Clones a schema object, expanding shorthand as it does it.
@@ -7,7 +8,7 @@ import MongoObject from 'mongo-object';
 function expandShorthand(schema) {
   const schemaClone = {};
 
-  _.each(schema, (definition, key) => {
+  forEach(schema, (definition, key) => {
     // CASE 1: Not shorthand. Just clone
     if (MongoObject.isBasicObject(definition)) {
       schemaClone[key] = { ...definition };

--- a/lib/validation/allowedValuesValidator.js
+++ b/lib/validation/allowedValuesValidator.js
@@ -1,12 +1,12 @@
 import { SimpleSchema } from '../SimpleSchema';
-
+import includes from 'lodash.includes';
 function allowedValuesValidator() {
   if (!this.valueShouldBeChecked) return;
 
   const allowedValues = this.definition.allowedValues;
   if (!allowedValues) return;
 
-  const isAllowed = allowedValues.includes(this.value);
+  const isAllowed = includes(allowedValues, this.value);
   return isAllowed ? true : SimpleSchema.ErrorTypes.VALUE_NOT_ALLOWED;
 }
 

--- a/lib/validation/allowedValuesValidator.js
+++ b/lib/validation/allowedValuesValidator.js
@@ -1,5 +1,3 @@
-import _ from 'underscore';
-
 import { SimpleSchema } from '../SimpleSchema';
 
 function allowedValuesValidator() {
@@ -8,7 +6,7 @@ function allowedValuesValidator() {
   const allowedValues = this.definition.allowedValues;
   if (!allowedValues) return;
 
-  const isAllowed = _.contains(allowedValues, this.value);
+  const isAllowed = allowedValues.includes(this.value);
   return isAllowed ? true : SimpleSchema.ErrorTypes.VALUE_NOT_ALLOWED;
 }
 

--- a/lib/validation/doStringChecks.js
+++ b/lib/validation/doStringChecks.js
@@ -1,5 +1,4 @@
 import { SimpleSchema } from '../SimpleSchema';
-import _ from 'underscore';
 
 function doStringChecks(def, keyValue) {
   // Is it a String?
@@ -25,7 +24,7 @@ function doStringChecks(def, keyValue) {
   // If regEx is an array of regular expressions, does the string match all of them?
   if (Array.isArray(def.regEx)) {
     let regExError;
-    _.every(def.regEx, re => {
+    def.regEx.every(re => {
       if (!re.test(keyValue)) {
         regExError = { type: SimpleSchema.ErrorTypes.FAILED_REGULAR_EXPRESSION, regExp: re.toString() };
         return false;

--- a/lib/validation/requiredValidator.js
+++ b/lib/validation/requiredValidator.js
@@ -1,4 +1,3 @@
-import _ from 'underscore';
 import { SimpleSchema } from '../SimpleSchema';
 
 // Check for missing required values. The general logic is this:
@@ -16,7 +15,7 @@ function requiredValidator() {
   // of those in $set or $setOnInsert because they will be created
   // by MongoDB while setting.
   const setKeys = Object.keys(this.obj.$set || {}).concat(Object.keys(this.obj.$setOnInsert || {}));
-  const willBeCreatedAutomatically = _.some(setKeys, sk => (sk.slice(0, this.key.length + 1) === `${this.key}.`));
+  const willBeCreatedAutomatically = setKeys.some(sk => (sk.slice(0, this.key.length + 1) === `${this.key}.`));
   if (willBeCreatedAutomatically) return;
 
   if (

--- a/package.json
+++ b/package.json
@@ -29,13 +29,16 @@
   "dependencies": {
     "clone": "1.0.2",
     "deep-extend": "0.4.1",
+    "lodash.find": "^4.6.0",
     "lodash.findwhere": "^3.1.0",
     "lodash.foreach": "^4.5.0",
+    "lodash.includes": "^4.3.0",
     "lodash.isempty": "^4.4.0",
     "lodash.isobject": "^3.0.2",
     "lodash.omit": "^4.5.0",
     "lodash.pick": "^4.4.0",
     "lodash.union": "^4.6.0",
+    "lodash.uniq": "^4.5.0",
     "message-box": "0.0.2",
     "mongo-object": "0.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -29,9 +29,15 @@
   "dependencies": {
     "clone": "1.0.2",
     "deep-extend": "0.4.1",
+    "lodash.findwhere": "^3.1.0",
+    "lodash.foreach": "^4.5.0",
+    "lodash.isempty": "^4.4.0",
+    "lodash.isobject": "^3.0.2",
+    "lodash.omit": "^4.5.0",
+    "lodash.pick": "^4.4.0",
+    "lodash.union": "^4.6.0",
     "message-box": "0.0.2",
-    "mongo-object": "0.0.1",
-    "underscore": "1.8.3"
+    "mongo-object": "0.0.1"
   },
   "devDependencies": {
     "babel-cli": "^6.10.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "lodash.pick": "^4.4.0",
     "lodash.union": "^4.6.0",
     "message-box": "0.0.2",
-    "mongo-object": "0.0.1"
+    "mongo-object": "0.0.2"
   },
   "devDependencies": {
     "babel-cli": "^6.10.1",


### PR DESCRIPTION
Simple Schema does not not depend on underscore anymore, but on the required lodash methods or es6 alternatives.

Also updated mongo object to latest version