### PR TITLE
check if autoValue function is defaultAutoValueFunction

### DIFF
--- a/lib/SimpleSchema.js
+++ b/lib/SimpleSchema.js
@@ -845,8 +845,9 @@ function checkAndScrubDefinition(fieldName, definition, options, fullSchemaObj) 
   // defaultValue -> autoValue
   // We support defaultValue shortcut by converting it immediately into an
   // autoValue.
+
   if ('defaultValue' in internalDefinition) {
-    if ('autoValue' in internalDefinition) {
+    if ('autoValue' in internalDefinition && internalDefinition.autoValue.name !== 'defaultAutoValueFunction') {
       console.warn(`SimpleSchema: Found both autoValue and defaultValue options for "${fieldName}". Ignoring defaultValue.`);
     } else {
       if (fieldName.endsWith('.$')) {


### PR DESCRIPTION
Issue: https://github.com/aldeed/node-simple-schema/issues/114

I didn't take a deep look at the code so this might be wrong, but from what I can tell the warning happens because of SimpleSchema's own `defaultAutoValueFunction` function is assigned as an `autoValue`:

```js
internalDefinition.autoValue = getDefaultAutoValueFunction(internalDefinition.defaultValue);
```

This could be a problem if the schema-checking code runs multiple times on the same schema for whatever reason (I think in my case it happens when I'm extending it with additional fields), so I added a check to make sure the warning doesn't trigger on `defaultAutoValueFunction`. 