### PR TITLE
Removed array short-handler from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,8 @@ is equivalent to:
 }
 ```
 
+**Note:** This only applies to shorthand definitions, not to the longhand definition. This example will throw an error `{ friends: { type: [String] } }` even though it was valid in [the meteor-version of this package](https://github.com/aldeed/meteor-simple-schema/).
+
 ### Multiple Definitions For One Key
 
 You can define two or more different ways in which a key will be considered valid:

--- a/README.md
+++ b/README.md
@@ -331,23 +331,6 @@ is equivalent to:
 }
 ```
 
-You can also set the schema key to an array of some type:
-
-```js
-{
-  friends: [String],
-}
-```
-
-is equivalent to:
-
-```js
-{
-  friends: { type: Array },
-  'friends.$': { type: String },
-}
-```
-
 ### Multiple Definitions For One Key
 
 You can define two or more different ways in which a key will be considered valid:

--- a/README.md
+++ b/README.md
@@ -331,6 +331,23 @@ is equivalent to:
 }
 ```
 
+You can also set the schema key to an array of some type:
+
+```js
+{
+  friends: [String],
+}
+```
+
+is equivalent to:
+
+```js
+{
+  friends: { type: Array },
+  'friends.$': { type: String },
+}
+```
+
 ### Multiple Definitions For One Key
 
 You can define two or more different ways in which a key will be considered valid:


### PR DESCRIPTION
Removed the short-handler as it was dropped quite a while ago already. See https://github.com/aldeed/node-simple-schema/issues/7

I've also added these changes to the update-guide of the meteor package: https://github.com/aldeed/meteor-simple-schema/pull/710