### PR TITLE
Throw explicit Error when redefining Object methods

### DIFF
--- a/lib/SimpleSchema.js
+++ b/lib/SimpleSchema.js
@@ -417,6 +417,10 @@ class SimpleSchema {
 
       // Merge/extend with any existing definition
       if (this._schema[fieldName]) {
+        if (!this._schema.hasOwnProperty(fieldName)) {
+          // fieldName is actually a method from Object itself!
+          throw new Error(`${fieldName} key is actually the name of a method on Object, please rename it`);
+        }
         this._schema[fieldName] = {
           ...this._schema[fieldName],
           ...(_.omit(definition, 'type')),

--- a/lib/SimpleSchema.tests.js
+++ b/lib/SimpleSchema.tests.js
@@ -25,6 +25,16 @@ describe('SimpleSchema', function () {
     }).toThrow('foo key is missing "type"');
   });
 
+  it('throws an explicit error if you define fields that override object methods', function () {
+    expect(function () {
+      return new SimpleSchema({
+        valueOf: {
+          type: String,
+        },
+      });
+    }).toThrow('valueOf key is actually the name of a method on Object');
+  });
+
   describe('nesting', function () {
     it('throws an error if a nested schema defines a field that its parent also defines', function () {
       expect(function () {


### PR DESCRIPTION
Just lost 2 hours debugging why my schema with a `watch` field worked in Chrome but crashed with a cryptic `TypeError: _this5._schema[fieldName].type is undefined` in Firefox :sob: 

Turns out `Object.prototype.watch` is still present in Firefox and causes the error.

This PR will raise a clearer Error should this happen to someone else :smile: 