### PR TITLE
Issue/156

### DIFF
--- a/lib/utility.js
+++ b/lib/utility.js
@@ -12,20 +12,24 @@ function dateToDateString(date) {
 }
 
 function isObjectWeShouldTraverse(val) {
-  if (val !== Object(val)) return false;
+  try {
+    if (val !== Object(val)) return false;
+       
+    // There are some object types that we know we shouldn't traverse because
+    // they will often result in overflows and it makes no sense to validate them.
+    if (val instanceof Date) return false;
+    if (val instanceof Int8Array) return false;
+    if (val instanceof Uint8Array) return false;
+    if (val instanceof Uint8ClampedArray) return false;
+    if (val instanceof Int16Array) return false;
+    if (val instanceof Uint16Array) return false;
+    if (val instanceof Int32Array) return false;
+    if (val instanceof Uint32Array) return false;
+    if (val instanceof Float32Array) return false;
+    if (val instanceof Float64Array) return false;
+  } catch (e){
 
-  // There are some object types that we know we shouldn't traverse because
-  // they will often result in overflows and it makes no sense to validate them.
-  if (val instanceof Date) return false;
-  if (val instanceof Int8Array) return false;
-  if (val instanceof Uint8Array) return false;
-  if (val instanceof Uint8ClampedArray) return false;
-  if (val instanceof Int16Array) return false;
-  if (val instanceof Uint16Array) return false;
-  if (val instanceof Int32Array) return false;
-  if (val instanceof Uint32Array) return false;
-  if (val instanceof Float32Array) return false;
-  if (val instanceof Float64Array) return false;
+  }
 
   return true;
 }

--- a/lib/utility.js
+++ b/lib/utility.js
@@ -14,7 +14,6 @@ function dateToDateString(date) {
 function isObjectWeShouldTraverse(val) {
   try {
     if (val !== Object(val)) return false;
-       
     // There are some object types that we know we shouldn't traverse because
     // they will often result in overflows and it makes no sense to validate them.
     if (val instanceof Date) return false;
@@ -27,8 +26,8 @@ function isObjectWeShouldTraverse(val) {
     if (val instanceof Uint32Array) return false;
     if (val instanceof Float32Array) return false;
     if (val instanceof Float64Array) return false;
-  } catch (e){
-
+  } catch (e) {
+    return false;
   }
 
   return true;

--- a/lib/utility.js
+++ b/lib/utility.js
@@ -12,6 +12,7 @@ function dateToDateString(date) {
 }
 
 function isObjectWeShouldTraverse(val) {
+  // Some of these types don't exist in old browsers so we'll catch and return false in those cases
   try {
     if (val !== Object(val)) return false;
     // There are some object types that we know we shouldn't traverse because


### PR DESCRIPTION
Wrap the type checking in try statement to catch errors as seen with Uint8ClampedArray values in IE. If an error was to be thrown, the function returns falsy as to not traverse the object.